### PR TITLE
Mark PNG files as binary files

### DIFF
--- a/build.lua
+++ b/build.lua
@@ -164,6 +164,7 @@ docfiles = {"tagpdf.tex",
             "examples/**/ex-*.pdf"}
 
 textfiles= {"doc/CTANREADME.md"}
+binaryfiles = {"*.pdf", "*.png", "*.zip"}
 
 ctanreadme= "CTANREADME.md"
 


### PR DESCRIPTION
I still have some trouble reproducing this, but I think this should fix the PNG issue for l3build zip files.