### PR TITLE
It should be "heuristica", not "Heuristica"

### DIFF
--- a/doc/tagpdf.tex
+++ b/doc/tagpdf.tex
@@ -13,7 +13,7 @@
 \usepackage[english]{babel}
 
 \usepackage{unicode-math}
-\setmainfont{Heuristica}
+\setmainfont{heuristica}
 \usepackage[nopatch]{microtype}
 \makeatletter
 % see https://github.com/schlcht/microtype/issues/8


### PR DESCRIPTION
On Linux, which has case sensitive file names, "heuristica" works but "Heuristica" does not.