### PR TITLE
documentation typo: fix missing `\` in `\verb`

### DIFF
--- a/doc/tagpdf.tex
+++ b/doc/tagpdf.tex
@@ -1656,9 +1656,9 @@ The key-val list understands the following keys:
    \end{lstlisting}
 
    \item[\PrintKeyName{AFinline-o}]
-    This is like verb+AFinline+, but it expands the value once.
+    This is like \verb+AFinline+, but it expands the value once.
 
-\item[\PrintKeyName{texsource}] This is like verb+AFinline-o+, but it 
+\item[\PrintKeyName{texsource}] This is like \verb+AFinline-o+, but it 
     creates a tex-file, with mime type \texttt{application/x-tex} and the 
     AFRelationship \texttt{Source}. 
 


### PR DESCRIPTION
Fixes a missing `\` in `\verb+AFinline+` and `\verb+AFinline-o+`.