### PR TITLE
small doc corrections

### DIFF
--- a/tagpdf-checks.dtx
+++ b/tagpdf-checks.dtx
@@ -58,7 +58,7 @@
 % \end{function}
 % \begin{function}[EXP]{\tag_get:n}
 %  \begin{syntax}
-%  \cs{tag_get:n}\Arg{keyword}
+%  \cs{tag_get:n} \Arg{keyword}
 %  \end{syntax}
 % This is a generic command to retrieve data for the current structure or
 % mc-chunk. Currently
@@ -68,7 +68,7 @@
 %
 % \begin{function}[pTF,EXP]{\tag_if_box_tagged:N}
 %  \begin{syntax}
-%  \cs{tag_if_box_tagged:N}\Arg{box}
+%  \cs{tag_if_box_tagged:NTF} \meta{box} \Arg{true code} \Arg{false code}
 %  \end{syntax}
 % This tests if a box contains tagging commands.
 % It relies currently on that the code, that saved the box, correctly sets

--- a/tagpdf-mc-shared.dtx
+++ b/tagpdf-mc-shared.dtx
@@ -52,7 +52,7 @@
 % \section{Public Commands}
 %  \begin{function}{\tag_mc_begin:n,\tag_mc_end:}
 %   \begin{syntax}
-%     \cs{tag_mc_begin:n}\Arg{key-values}\\
+%     \cs{tag_mc_begin:n} \Arg{key-values}\\
 %     \cs{tag_mc_end:}
 %   \end{syntax}
 % These commands insert the end code of the marked content.
@@ -64,7 +64,7 @@
 %
 %  \begin{function}{\tag_mc_use:n}
 %   \begin{syntax}
-%     \cs{tag_mc_use:n}\Arg{label}
+%     \cs{tag_mc_use:n} \Arg{label}
 %   \end{syntax}
 % These command allow to record a marked content that was stashed away before
 % into the current structure. A marked content can be used only once --
@@ -94,7 +94,7 @@
 %   }
 %   \begin{syntax}
 %     \cs{tag_mc_end_push:} \\
-%     \cs{tag_mc_begin_pop:n}\Arg{key-values}
+%     \cs{tag_mc_begin_pop:n} \Arg{key-values}
 %   \end{syntax}
 % If there is an open mc chunk,
 % \cs{tag_mc_end_push:} ends it and pushes its tag of the (global) stack.
@@ -113,7 +113,7 @@
 %
 % \begin{function}[ EXP,added=2023-06-11]{\tag_mc_reset_box:N}
 %   \begin{syntax}
-%     \cs{tag_mc_reset_box:N} \Arg{box} 
+%     \cs{tag_mc_reset_box:N} \meta{box} 
 %   \end{syntax}
 %   This resets in lua mode the mc attributes to the one currently in use.
 %   It does nothing in generic mode.
@@ -121,7 +121,7 @@
 %
 % \begin{function}[added=2024-11-18]{\tag_mc_add_missing_to_stream:Nn}
 %   \begin{syntax}
-%     \cs{tag_mc_add_missing_to_stream:Nn} \Arg{box} \Arg {stream name}
+%     \cs{tag_mc_add_missing_to_stream:Nn} \meta{box} \Arg{stream name}
 %   \end{syntax}
 %   This command is only needed in generic mode, in lua mode it gobbles its arguments.
 %   In generic mode it adds MC literals to the stream that are missing because of
@@ -138,7 +138,7 @@
 % 
 % \begin{function}[added=2024-11-18]{\tag_mc_new_stream:n}
 %   \begin{syntax}
-%     \cs{tag_mc_new_stream:n} \Arg {stream name}
+%     \cs{tag_mc_new_stream:n} \Arg{stream name}
 %   \end{syntax}
 %   This declares the interface needed to handle 
 %   a new stream with \cs{tag_mc_add_missing_to_stream:Nn}.

--- a/tagpdf-roles.dtx
+++ b/tagpdf-roles.dtx
@@ -88,7 +88,7 @@
 % 
 % \begin{function}[TF]{\tag_check_child:nn}
 % \begin{syntax}
-% \cs{tag_check_child:nn}\Arg{tag}\Arg{namespace} \Arg{true code} \Arg{false code}
+% \cs{tag_check_child:nnTF} \Arg{tag} \Arg{namespace} \Arg{true code} \Arg{false code}
 % \end{syntax}
 % This checks if the tag \meta{tag} from the name space \meta{namespace}
 % can be used at the current position. In tagpdf-base it is always true. 
@@ -282,7 +282,7 @@
 % 
 % \begin{function}{\@@_role_NS_new:nnn}
 %  \begin{syntax}
-%   \cs{@@_role_NS_new:nnn}\Arg{shorthand}\Arg{URI-ID}{Schema}
+%   \cs{@@_role_NS_new:nnn} \Arg{shorthand} \Arg{URI-ID} \Arg{Schema}
 %  \end{syntax}
 % \end{function}
 % \begin{macro}{\@@_role_NS_new:nnn}

--- a/tagpdf-struct.dtx
+++ b/tagpdf-struct.dtx
@@ -53,9 +53,9 @@
 % \section{Public Commands}
 % \begin{function}{\tag_struct_begin:n,\tag_struct_end:,\tag_struct_end:n}
 %   \begin{syntax}
-%     \cs{tag_struct_begin:n}\Arg{key-values}\\
+%     \cs{tag_struct_begin:n} \Arg{key-values}\\
 %     \cs{tag_struct_end:}\\
-%     \cs{tag_struct_end:n}\Arg{tag}
+%     \cs{tag_struct_end:n} \Arg{tag}
 %   \end{syntax}
 %  These commands start and end a new structure.
 %  They don't start a group. They set all their values globally.
@@ -66,8 +66,8 @@
 % \end{function}
 %  \begin{function}{\tag_struct_use:n,\tag_struct_use_num:n}
 %   \begin{syntax}
-%     \cs{tag_struct_use:n}\Arg{label}\\
-%     \cs{tag_struct_use_num:n}\Arg{structure number}
+%     \cs{tag_struct_use:n} \Arg{label}\\
+%     \cs{tag_struct_use_num:n} \Arg{structure number}
 %   \end{syntax}
 % These commands insert a structure previously stashed away as kid
 % into the currently active structure.
@@ -76,7 +76,7 @@
 % \end{function}
 %  \begin{function}{\tag_struct_object_ref:n,\tag_struct_object_ref:e}
 %   \begin{syntax}
-%     \cs{tag_struct_object_ref:n}\Arg{struct number}
+%     \cs{tag_struct_object_ref:n} \Arg{structure number}
 %   \end{syntax}
 %   This is a small wrapper around |\pdf_object_ref:n| to retrieve the
 %   object reference of the structure with the number \meta{struct number}.
@@ -91,7 +91,7 @@
 % here.
 %  \begin{function}{\tag_struct_insert_annot:nn}
 %   \begin{syntax}
-%     \cs{tag_struct_insert_annot:nn}\Arg{object reference}\Arg{struct parent number}
+%     \cs{tag_struct_insert_annot:nn} \Arg{object reference} \Arg{struct parent number}
 %   \end{syntax}
 % This inserts an annotation in the structure. \meta{object reference}
 % is there reference to the annotation. \meta{struct parent number}
@@ -110,7 +110,7 @@
 % 
 % \begin{function}{\tag_struct_gput:nnn}
 % \begin{syntax}
-%  \cs{tag_struct_gput:nnn}\Arg{structure number}\Arg{keyword}\Arg{value}
+%  \cs{tag_struct_gput:nnn} \Arg{structure number} \Arg{keyword} \Arg{value}
 %  \end{syntax}
 % This is a command that allows to update the data of a structure.
 % This often can't done simply by replacing the value, as we have to 
@@ -124,7 +124,7 @@
 %
 % \begin{function}{\tag_struct_gput_ref:nnn}
 % \begin{syntax}
-%  \cs{tag_struct_gput_ref:nnn}\Arg{structure number}\Arg{keyword}\Arg{value}
+%  \cs{tag_struct_gput_ref:nnn} \Arg{structure number} \Arg{keyword} \Arg{value}
 %  \end{syntax}
 % This is an user interface to add a Ref key to an
 % existing structure. The target structure doesn't have to exist yet

--- a/tagpdf-user.dtx
+++ b/tagpdf-user.dtx
@@ -67,7 +67,7 @@
 %
 % \begin{function}{\tag_tool:n,\tagtool}
 % \begin{syntax}
-% \cs{tag_tool:n}\Arg{key val}
+% \cs{tag_tool:n} \Arg{key val}
 % \end{syntax}
 % The tagging of basic document elements will require a variety of small commands
 % to configure and adapt the tagging. This command will collect them under a command
@@ -78,7 +78,7 @@
 % \section{Commands related to mc-chunks}
 % \begin{function}{\tagmcbegin, \tagmcend,\tagmcuse}
 % \begin{syntax}
-% \cs{tagmcbegin} \Arg{key-val}\\
+% \cs{tagmcbegin}\Arg{key-val}\\
 % \cs{tagmcend}\\
 % \cs{tagmcuse}\Arg{label}
 % \end{syntax}
@@ -90,7 +90,7 @@
 %
 % \begin{function}{\tagmcifinTF}
 % \begin{syntax}
-% \cs{tagmcifin} \Arg{true code}\Arg{false code}
+% \cs{tagmcifinTF}\Arg{true code}\Arg{false code}
 % \end{syntax}
 % This is a wrapper around |\tag_mc_if_in:TF|.
 % and tests if an mc is open or not. It is mostly of
@@ -104,7 +104,7 @@
 % \section{Commands related to structures}
 % \begin{function}{\tagstructbegin, \tagstructend,\tagstructuse}
 % \begin{syntax}
-% \cs{tagstructbegin} \Arg{key-val}\\
+% \cs{tagstructbegin}\Arg{key-val}\\
 % \cs{tagstructend}\\
 % \cs{tagstructuse}\Arg{label}
 % \end{syntax}
@@ -118,7 +118,7 @@
 % \section{Debugging}
 % \begin{function}{\ShowTagging}
 %   \begin{syntax}
-%   \cs{ShowTagging} \Arg{key-val}
+%   \cs{ShowTagging}\Arg{key-val}
 %   \end{syntax}
 % This is a generic function to output various debugging helps. It not
 % necessarily stops the compilation. The keys and their function are described below.
@@ -270,7 +270,7 @@
 %  \cs{tag_socket_use_expandable:n} \Arg{socket name}\\
 %  \cs{UseTaggingSocket} \Arg{socket name} \\
 %  \cs{UseTaggingSocket} \Arg{socket name} \Arg{socket argument}\\
-%  \cs{UseTaggingSocket} \Arg{socket name} \Arg{socket argument}\Arg{socket argument}\\
+%  \cs{UseTaggingSocket} \Arg{socket name} \Arg{socket argument} \Arg{socket argument}\\
 % \end{syntax}
 % \end{function}
 % 

--- a/tagpdf.dtx
+++ b/tagpdf.dtx
@@ -53,10 +53,10 @@
 % \begin{documentation}
 % \begin{function}{\tag_suspend:n, \tag_resume:n,\tag_stop:n, \tag_start:n }%
 % \begin{syntax}
-% \cs{tag_suspend:n}\Arg{label}\\
-% \cs{tag_resume:n}\Arg{label}\\ 
-% \cs{tag_stop:n}\Arg{label} (\emph{deprecated})\\
-% \cs{tag_start:n}\Arg{label} (\emph{deprecated}) 
+% \cs{tag_suspend:n} \Arg{label}\\
+% \cs{tag_resume:n} \Arg{label}\\ 
+% \cs{tag_stop:n} \Arg{label} (\emph{deprecated})\\
+% \cs{tag_start:n} \Arg{label} (\emph{deprecated}) 
 % \end{syntax}
 % We need commands to stop tagging in some places.
 % They switches three local booleans and also stop the counting


### PR DESCRIPTION
Fixes a few `syntax` listings in tagpdf-code. Also standardizes the space between arguments for expl3 vs. 2e commands.