### PR TITLE
Ignore end of link in LuaTeX if no node is inserted

### DIFF
--- a/tagpdf-backend.dtx
+++ b/tagpdf-backend.dtx
@@ -1541,6 +1541,7 @@ ltx.@@.func.check_parent_child_rules=check_parent_child_rules
 %    \begin{macrocode}  
   if luatexbase.callbacktypes['linksplit'] then
    luatexbase.add_to_callback('linksplit', function(start_link, position)
+     if start_link == nil then return end
      local structnum =
        node.get_attribute(start_link,luatexbase.attributes.g__tag_structnum_attr)
      if structnum and structnum > -1 then 


### PR DESCRIPTION
If a link gets ended in a group less nested than the group the link was started in, then at the final location there is no link inserted. In order to inform the callback that the link is ending, the `linksplit` callback gets called with position `final` but since there is no link there the link node is `nil`. Catch and ignore this case since there is no annotation there which needs to be tagged.

Fixes #120.