### PR TITLE
typo fixes

### DIFF
--- a/tagpdf-checks.dtx
+++ b/tagpdf-checks.dtx
@@ -367,7 +367,7 @@
 % or has been undefined as the mc was already used.
 %    \begin{macrocode}
 \msg_new:nnn { tag } {mc-label-unknown}
-  { label~#1~unknown~or~has~been~already~used.\\
+  { label~#1~unknown~or~has~already~been~used.\\
     Either~rerun~or~remove~one~of~the~uses. }
 %    \end{macrocode}
 % \end{macro}
@@ -375,7 +375,7 @@
 % An mc-chunk can be inserted only in one structure. This indicates wrong coding
 % and so should at least give a warning.
 %    \begin{macrocode}
-\msg_new:nnn { tag } {mc-used-twice} { mc~#1~has~been~already~used }
+\msg_new:nnn { tag } {mc-used-twice} { mc~#1~has~already~been~used }
 %    \end{macrocode}
 % \end{macro}
 % \begin{macro}{mc-not-open}
@@ -424,7 +424,7 @@
   {
     Structure~#1~has~#2~kids~but~no~parent.\\
     It~is~turned~into~an~artifact.\\
-    Did~you~stash~a~structure~and~then~didn't~use~it?
+    Did~you~stash~a~structure~and~then~not~use~it?
   }
 
 %    \end{macrocode}
@@ -783,7 +783,7 @@
 % Currently only pdflatex and lualatex have some support for real spaces.
 %    \begin{macrocode}
 \msg_new:nnn { tag } {sys-no-interwordspace}
-  {engine/output~mode~#1~doesn't~support~the~interword~spaces}
+  {engine/output~mode~#1~doesn't~support~interword~spaces}
 %    \end{macrocode}
 % \end{macro}
 %
@@ -802,7 +802,7 @@
 %    \begin{macrocode}
 \msg_new:nnnn { tag } {para-hook-count-wrong}
   {The~number~of~automatic~begin~(#1)~and~end~(#2)~#3~para~hooks~differ!}
-  {This~quite~probably~a~coding~error~and~the~structure~will~be~wrong!}
+  {This~is~quite~probably~a~coding~error~and~the~structure~will~be~wrong!}
 %</package>
 %    \end{macrocode}
 % \end{macro}
@@ -1131,7 +1131,7 @@
 %
 % \begin{variable}{\g_@@_check_mc_used_intarray, \@@_check_init_mc_used:}
 % This variable holds the list of used mc numbers.
-% Everytime we store a mc-number we will add one the relevant array index
+% Every time we store a mc-number we will add one the relevant array index
 % If everything is right at the end there should be only 1 until the max count
 % of the mcid. 2 indicates that one mcid was used twice, 0 that we lost one.
 % In engines other than luatex the total number of all intarray entries

--- a/tagpdf-roles.dtx
+++ b/tagpdf-roles.dtx
@@ -1099,9 +1099,9 @@
 \pdf_version_compare:NnTF < {2.0}
   {
    \cs_new_protected:Npn \@@_role_check_parent_child:nnnnN #1 #2 #3 #4 #5
-    % #1 parent tag,% not necessarly rolemapped, but often the case
+    % #1 parent tag,% not necessarily rolemapped, but often the case
     % #2 NS (empty in pdf 1.x)
-    % #3 child tag, % not necessarly rolemapped, but often the case
+    % #3 child tag, % not necessarily rolemapped, but often the case
     % #4 NS (empty in pdf 1.x) 
     % #5 tl var: to give the result back. 
      {

--- a/tagpdf-user.dtx
+++ b/tagpdf-user.dtx
@@ -34,7 +34,7 @@
 % \fi
 % \title{^^A
 %   The \pkg{tagpdf-user} module\\
-%   Code related to \LaTeX2e user commands and document commands   ^^A
+%   Code related to \LaTeXe{} user commands and document commands   ^^A
 % }
 %
 % \author{^^A
@@ -293,7 +293,7 @@
 % that but in general we expect to always use \cs{UseTaggingSocket}.
 %
 % For special cases like in some \cs{halign} contexts we need a fully expandable
-% version of the commend. For these cases, \cs{UseExpandableTaggingSocket} can be
+% version of the command. For these cases, \cs{UseExpandableTaggingSocket} can be
 % used. To allow being expandable, it does not output any debugging information
 % if \cs{DebugSocketsOn} is in effect and therefore should be avoided whenever possible.
 %

--- a/tagpdf.dtx
+++ b/tagpdf.dtx
@@ -58,7 +58,7 @@
 % \cs{tag_start:n} \Arg{label} (\emph{deprecated})
 % \end{syntax}
 % We need commands to stop tagging in some places.
-% They switches three local booleans and also stop the counting
+% They switch three local booleans and also stop the counting
 % of paragraphs. If they are nested an inner \cs{tag_resume:n} will not
 % restart tagging.
 % \meta{label} is only used in debugging messages to allow to follow the nesting
@@ -73,8 +73,8 @@
 %  \tag_stop:, \tag_start:,
 %  \tagstop, \tagstart }
 % \emph{deprecated} These are variants of the above commands
-% without the debuging level. They are now deprecated and it
-% is recommended to use the kernel command
+% without the debugging level. They are now deprecated and it
+% is recommended to use the kernel commands
 % |\SuspendTagging|, |\ResumeTagging|, |\tag_suspend:n| and |\tag_resume:n|
 % instead.
 % \end{function}
@@ -96,7 +96,7 @@
 %    activate/tree,
 %    activate-tree (deprecated),
 %    }
-% This key activates the code that finalize the
+% This key activates the code that finalizes the
 % various trees. It should be used
 % only in special cases, e.g. for debugging.
 % \end{setupkeydecl}
@@ -118,7 +118,7 @@
 % \end{setupkeydecl}
 %
 %\begin{setupkeydecl}{activate/struct-dest,no-struct-dest (deprecated)}
-% The key allows to suppress the creation of structure destinations
+% This key allows to suppress the creation of structure destinations.
 % \end{setupkeydecl}
 %
 % \begin{setupkeydecl}{debug/log}
@@ -139,14 +139,14 @@
 % \item \texttt{false} and \texttt{off} deactivates the automatic
 % handling.
 % \item \texttt{char} Replaces the hyphens by U+00AD if the font contains this glyph.
-% Note that in some newer fonts U+00AD is an invisible character and so this could led
+% Note that in some newer fonts U+00AD is an invisible character and so this could lead
 % to disappearing hyphens.
 % \item \texttt{artifact} (default value) This keeps the hard hyphen U+002D but
 % surrounds it by an Artifact-MC. This only works if the document is tagged.
 % \item \texttt{true}, \texttt{on}  do the same as \texttt{artifact}.
 % \end{itemize}
 %
-% If tagging is not activate the softhyphen handling is not activated, by default. The hyphen
+% If tagging is not active the softhyphen handling is not activated, by default. The hyphen
 % stays a hard-hyphen. If is possible to use the \texttt{char} mode with
 % \begin{verbatim}
 % \DocumentMetadata{tagging=off,tagging-setup={activate/softhyphen=char},}
@@ -154,7 +154,7 @@
 % As \cs{tagpdfsetup} is deactivated at the begin of the class,
 % there is no interface to switch in the document.
 %
-% If tagging is active the default is \texttt{artifact} mode, this requires that \texttt{tagunmarked}
+% If tagging is active the default is \texttt{artifact} mode; this requires that \texttt{tagunmarked}
 % is active too. The mode can be switched at any time with \cs{tagpdfsetup}.
 % Switching on and off the softhyphen is a global operation,
 % a switch between artifact and char more is a local operation.
@@ -197,8 +197,8 @@
   {
     \PackageError{tagpdf}
      {
-       PDF~resource~management~is~no~active!\MessageBreak
-       tagpdf~will~no~work.
+       PDF~resource~management~is~not~active!\MessageBreak
+       tagpdf~will~not~work.
      }
      {
        Activate~it~with \MessageBreak

--- a/testfiles-pdftex/orphan-01.tlg
+++ b/testfiles-pdftex/orphan-01.tlg
@@ -14,7 +14,7 @@ Package tagpdf Info: writing NameSpaces
 Package tagpdf Info: writing StructElems
 Package tagpdf Warning: Structure 6 has 2 kids but no parent.
 (tagpdf)                It is turned into an artifact.
-(tagpdf)                Did you stash a structure and then didn't use it?
+(tagpdf)                Did you stash a structure and then not use it?
 Package tagpdf Info: writing Root
 ***************
 Compilation 1 of test file completed with exit status 0

--- a/testfiles/test-mc-used-twice.tlg
+++ b/testfiles/test-mc-used-twice.tlg
@@ -1,8 +1,8 @@
 This is a generated file for the l3build validation system.
 Don't change this file in any respect.
-Package tagpdf Warning: mc A has been already used
-Package tagpdf Warning: mc A has been already used
-Package tagpdf Warning: mc A has been already used
+Package tagpdf Warning: mc A has already been used
+Package tagpdf Warning: mc A has already been used
+Package tagpdf Warning: mc A has already been used
 [1
 ]<<latex-list-css.html>><<latex-align-css.html>> (test-mc-used-twice.aux)
 Package tagpdf Info: Finalizing the tagging structure:


### PR DESCRIPTION
Fixes a few spelling and grammar typos, including in messages (so some tests will have to be updated; will do once the tests run after the PR is created). Definitely not a systematic review, just a few I noticed.